### PR TITLE
A few edits for clarity and consistency

### DIFF
--- a/content/blog/2018/03/2018-03-19-introducing-jenkins-x.adoc
+++ b/content/blog/2018/03/2018-03-19-introducing-jenkins-x.adoc
@@ -8,26 +8,26 @@ tags:
 author: jstrachan
 ---
 
-We are excited to share and invite the community to join us on a project we’ve been thinking about over the last few months called http://jenkins-x.io[Jenkins X] which extends the Jenkins ecosystem to solve the problem of automating CI / CD in the cloud.
+We are excited to share and invite the community to join us on a project we’ve been thinking about over the last few months called http://jenkins-x.io[Jenkins X] which extends the Jenkins ecosystem to solve the problem of automating CI/CD in the cloud.
 
 == Background
 
 The last few years have seen massive changes in the software industry:
 
-* use of immutable container images for distributing software which are smaller, easier to work with and have cheaper hardware costs than VMs (approx 20% less on average)
+* use of immutable container images for distributing software which are smaller, easier to work with and lead to cheaper infrastructure costs than VMs alone (approx 20% less on average)
 * https://kubernetes.io/[Kubernetes] has become the defacto way of installing, upgrading, operating and managing containers at scale on any public or hybrid cloud 
 ** 2018 is the year all the major public clouds, operating system vendors and PaaS offerings support https://kubernetes.io/[Kubernetes] natively
-** we now have open source industry standard for distributing, installing and managing applications on any cloud!
-* increased adoption of microservices and cloud native applications leading to massive increase in the number of components which require CI / CD along with increased release frequency
+** we now have an open source industry standard for distributing, installing and managing applications on any cloud!
+* increased adoption of microservices and cloud native applications leading to massive increase in the number of components which require CI/CD along with increased release frequency
 * improvements in DevOps practices coming from the community such as the https://puppet.com/blog/2017-state-devops-report-here[State of DevOps Report] which show the approach of high performing teams
 ** increasingly many businesses now realise that to compete you have to deliver value quickly via software
 ** teams need to become high performing if the business is to succeed
 
-All of this adds up to an increased demand for teams to have a solution for cloud native CI / CD with lots of automation!
+All of this adds up to an increased demand for teams to have a solution for cloud native CI/CD with lots of automation!
 
 == Introducing Jenkins X
 
-http://jenkins-x.io[Jenkins X] is a project which rethinks how developers should interact with CI / CD in the cloud with a focus on making development teams productive through automation, tooling and DevOps best practices.
+http://jenkins-x.io[Jenkins X] is a project which rethinks how developers should interact with CI/CD in the cloud with a focus on making development teams productive through automation, tooling and DevOps best practices.
 
 http://jenkins-x.io[Jenkins X] is open source and we invite you to give us feedback and to contribute to the project.
 
@@ -35,15 +35,15 @@ image::http://jenkins-x.io/images/logo.png[Jenkins X Logo,200,200]
 
 === Whats the big deal?
 
-For many years Jenkins has been capable of doing pretty much anything in the CI / CD space; the challenge has always been figuring out how to get the right plugins, configuration and code to work together in your `Jenkinsfile`.
+For many years Jenkins has been capable of doing pretty much anything in the CI/CD space; the challenge has always been figuring out how to get the right plugins, configuration and code to work together in your `Jenkinsfile`.
 
-For me the big deal about Jenkins X is as a developer you can type one command http://jenkins-x.io/developing/create-spring/[jx create spring],  http://jenkins-x.io/developing/create-quickstart/[jx create quickstart] or http://jenkins-x.io/developing/import/[jx import] and get your source code, git repository and application created, automatically built and deployed to Kubernetes on each Pull Request or git push with full CI / CD complete with Environments and Promotion via GitOps!
+For me the big deal about Jenkins X is as a developer you can type one command http://jenkins-x.io/developing/create-spring/[jx create spring],  http://jenkins-x.io/developing/create-quickstart/[jx create quickstart] or http://jenkins-x.io/developing/import/[jx import] and get your source code, git repository and application created, automatically built and deployed to Kubernetes on each Pull Request or git push with full CI/CD complete with Environments and Promotion via GitOps!
 
-Developers and teams don't have to waste valuable time figuring out how to package software as docker images, create the Kubernetes YAML to run their application on kubernetes, create Preview environments or even learn how to implement CI / CD pipelines with declarative pipeline-as-code `Jenkinsfiles`. Its all automated for you out of the box! So you can focus instead on delivering value!
+Developers and teams don't have to waste valuable time figuring out how to package software as docker images, create the Kubernetes YAML to run their application on kubernetes, create Preview environments or even learn how to implement CI/CD pipelines with declarative pipeline-as-code `Jenkinsfiles`. Its all automated for you out of the box! So you can focus instead on delivering value!
 
-Note that in Jenkins X we don't hide anything; so if you do want to hack the `Dockerfile`, `Jenkinsfile` or helm charts for your apps or their environments then go right a head - those are all available versioned in git with the rest of your source code with full CI / CD on it all. GitOps FTW!
+Note that in Jenkins X we don't hide anything; if you do want to hack the `Dockerfile`, `Jenkinsfile` or Helm charts for your apps or their environments then go right ahead - those are all available versioned in git with the rest of your source code with full CI/CD on it all. GitOps FTW!
 
-So with Jenkins X we can automate CI / CD and DevOps best practices for you - so you can become a faster performing team! Let your butler do more work for you!
+So with Jenkins X we can automate CI/CD and DevOps best practices for you - so you can become a faster performing team! Let your butler do more work for you!
 
 == Demo 
 
@@ -65,15 +65,15 @@ You can check out http://jenkins-x.io/demos/[more demos here].
 
 Now lets walk through the features of Jenkins X that we showed in the demo:
 
-=== Automated CI / CD Pipelines
+=== Automated CI/CD Pipelines
 
 Create http://jenkins-x.io/developing/create-spring/[new Spring Boot projects],  http://jenkins-x.io/developing/create-quickstart/[new quickstarts]  or http://jenkins-x.io/developing/import/[import existing source code] quickly into Jenkins X via the http://jenkins-x.io/commands/jx/[jx command line tool] and:
 
-* get a Pipeline automatically setup for you that implements best practice CI / CD features:
-** creates a `Jenkinsfile` for defining the CI / CD pipelines through declarative pipeline-as-code
+* get a Pipeline automatically setup for you that implements best practice CI/CD features:
+** creates a `Jenkinsfile` for defining the CI/CD pipelines through declarative pipeline-as-code
 ** creates a `Dockerfile` for packaging the application up as an immutable container image (for applications which generate images)
 ** creates a https://docs.helm.sh/developing_charts/#charts[Helm chart] for deploying and running your application on https://kubernetes.io/[Kubernetes]
-* ensures your code is in a git repository (e.g. GitHub) with the necessary webhooks to trigger the Jenkins CI / CD pipelines on push events
+* ensures your code is in a git repository (e.g. GitHub) with the necessary webhooks to trigger the Jenkins CI/CD pipelines on push events
 * triggers the first release pipeline to promote your application to your teams _Staging_ Environment
 
 Then on each Pull Request:
@@ -115,7 +115,7 @@ However it is easy to change the  configuration of how many environments you nee
 
 Jenkins X lets you create http://jenkins-x.io/about/features/#preview-environments[Preview Environments] for Pull Requests. Typically this happens automatically in the Pull Request Pipelines when a Pull Request is submitted but you can also perform this manually yourself via the http://jenkins-x.io/developing/preview/[jx preview] command.
 
-The following happens when a preview environment is created:
+The following happens when a Preview Environment is created:
 
 * a new http://jenkins-x.io/about/features/#environments[Environment] of kind `Preview` is created along with a https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/[kubernetes namespace] which show up the http://jenkins-x.io/commands/jx_get_environments/[jx get environments] command along with the http://jenkins-x.io/developing/kube-context/[jx environment and jx namespace commands] so you can see which preview environments are active and switch into them to look around
 * the Pull Request is built as a preview docker image and chart and deployed into the preview environment
@@ -129,7 +129,7 @@ This is particularly useful if you are working on a web application or REST endp
 
 If the commit comments reference issues (e.g. via the text `fixes #123`) then Jenkins X pipelines will generate release notes like those of https://github.com/jenkins-x/jx/releases[the jx releases].
 
-Also as the version with those new commits is promoted to `Staging` or `Production` you will get automated comments on each fixed issue that the issue is now available for review in the corresponding environment along with a link to the release notes and a link to the app running in that environment. e.g.
+Also, as the version associated with those new commits is promoted to `Staging` or `Production`, you will get automated comments on each fixed issue that the issue is now available for review in the corresponding environment along with a link to the release notes and a link to the app running in that environment. e.g.
 
 image::http://jenkins-x.io/images/issue-comment.png[Issue Comment]
 
@@ -137,9 +137,9 @@ image::http://jenkins-x.io/images/issue-comment.png[Issue Comment]
 
 == Getting started
 
-Hopefully you now want to give Jenkins X a try. One of the great features of Jenkins is its super easy to get started: install Java, download a war and run via `java -jar jenkins.war`.
+Hopefully you now want to give Jenkins X a try. One of the great features of Jenkins is that it's super easy to get started: install Java, download a war and run via `java -jar jenkins.war`.
 
-With Jenkins X we've tried to follow a similarly simple experience. One complication is that Jenkins X has more moving pieces than a single JVM; it also needs a Kubernetes cluster too :)
+With Jenkins X we've tried to follow a similarly simple experience. One complication is that Jenkins X has more moving pieces than a single JVM; it also needs a Kubernetes cluster :)
 
 First you need to http://jenkins-x.io/getting-started/install/[download and install the jx command line tool] so its on your `PATH`.
 
@@ -149,9 +149,9 @@ Then you need to run a single command to http://jenkins-x.io/getting-started/cre
 jx create cluster gke
 ----
 
-Today we support creating kubernetes clusters and installing Jenkins X on Amazon (AWS), Google (GKE) and Microsofts Azure. We hope to support AWS EKS soon. We do support http://jenkins-x.io/getting-started/create-cluster/[minikube] too; though folks often struggle getting minikube running on their laptops so highly recommend using a public cloud if you can.
+Today we support creating Kubernetes clusters and installing Jenkins X on Amazon (AWS), Google (GKE) and Microsoft Azure. We hope to support AWS EKS soon.
 
-At the time of writing the easiest cloud to get started with is Google's GKE so we recommend you start there unless you already use AWS or Azure. But Amazon and Microsoft are working hard to make Kubernete clusters as easy to create and manage as they are on GKE.
+At the time of writing the easiest cloud to get started with is Google's GKE so we recommend you start there unless you already use AWS or Azure. But Amazon and Microsoft are working hard to make Kubernetes clusters as easy to create and manage as they are on GKE.
 
 All the public clouds have a free tier so you should be able to spin up a Kubernetes cluster and install Jenkins X for a few hours then tear it down and it should be cheaper than a cup of coffee (probably free!). Just remember to tear down the cluster when you are done!
 
@@ -169,16 +169,16 @@ allowfullscreen></iframe>
 
 If you really don't want to use the public cloud, you can http://jenkins-x.io/getting-started/install-on-cluster/[install Jenkins X on an existing kubernetes cluster] (if it has RBAC enabled!).
 
-We don't recommend folks use https://github.com/kubernetes/minikube[minikube] to try out Jenkins X if you can possibly avoid it because so many folks we know who try this hit issues with minikube either not working due to old virtualisation, docker or CLI tools are installed or their laptop gets low of resources. However if you can run minikube yourself and your machine is big enough then sure you can http://jenkins-x.io/getting-started/create-cluster/[install Jenkins X on it].
+We don't recommend folks use https://github.com/kubernetes/minikube[minikube] to try out Jenkins X. Many folks we know who try this hit issues with minikube either not working due to old virtualisation, conflicts with Docker or other CLI tools that are installed, or simply because their laptop gets low of resources. However if you can run minikube yourself and your machine is big enough, then sure you can http://jenkins-x.io/getting-started/create-cluster/[install Jenkins X on it].
 
 
 == Relationship between Jenkins and Jenkins X
 
-Jenkins is the core CI / CD engine within Jenkins X. So Jenkins X is built on the massive shoulders of Jenkins and its awesome community.
+Jenkins is the core CI/CD engine within Jenkins X. So Jenkins X is built on the massive shoulders of Jenkins and its awesome community.
 
-We are https://github.com/jenkinsci/jep/tree/master/jep/400[proposing Jenkins X as a sub project] within the Jenkins foundation as Jenkins X has a different focus: automating CI / CD for the cloud using Jenkins plus other open source tools like Kubernetes, Helm, Git, Nexus/Artifactory etc.
+We are https://github.com/jenkinsci/jep/tree/master/jep/400[proposing Jenkins X as a sub project] within the Jenkins foundation as Jenkins X has a different focus: automating CI/CD for the cloud using Jenkins plus other open source tools like Kubernetes, Helm, Git, Nexus/Artifactory etc.
 
-Over time we are hoping Jenkins X can help drive some changes in Jenkins itself to become more cloud native which will benefit the wider Jenkins community in addition to Jenkins X.
+Over time we are hoping Jenkins X can help drive some changes in Jenkins itself to become more cloud native, which will benefit the wider Jenkins community in addition to Jenkins X.
 
 == Please join us!
 
@@ -197,11 +197,11 @@ If you're thinking of contributing here's some ideas:
 ** for more long term goals we've the http://jenkins-x.io/contribute/roadmap[roadmap]
 ** we could always use more test cases and to improve test coverage!
 
-To help get faster feedback we are using Jenkins X as the CI / CD platform to develop Jenkins X itself. For example Jenkins X creates https://github.com/jenkins-x/jx/releases[all the releases and release notes]. We'll talk more about https://github.com/jenkins-x/updatebot[UpdateBot] in a future blog post but you can see all the https://github.com/pulls?q=is%3Apr+archived%3Afalse+user%3Ajenkins-x+label%3Aupdatebot+is%3Aclosed[automated pull requests generated] in the various Jenkins X pipelines via https://github.com/jenkins-x/updatebot[UpdateBot] pushing version changes from upstream dependencies into downstream repositories.
+To help get faster feedback we are using Jenkins X as the CI/CD platform to develop Jenkins X itself. For example Jenkins X creates https://github.com/jenkins-x/jx/releases[all the releases and release notes]. We'll talk more about https://github.com/jenkins-x/updatebot[UpdateBot] in a future blog post but you can see all the https://github.com/pulls?q=is%3Apr+archived%3Afalse+user%3Ajenkins-x+label%3Aupdatebot+is%3Aclosed[automated pull requests generated] in the various Jenkins X pipelines via https://github.com/jenkins-x/updatebot[UpdateBot] pushing version changes from upstream dependencies into downstream repositories.
 
-Note that the Jenkins community tends to use IRC for chat and the kubernetes community uses Slack so Jenkins X has rooms for http://jenkins-x.io/community/[both IRC and slack] depending on which chat technology you prefer - as the Jenkins X community will be working closely with both the Jenkins community and the various Kubernetes communities (kubernetes, helm, skaffold, istio et al).
+Note that the Jenkins community tends to use IRC for chat and the Kubernetes community uses Slack, so Jenkins X has rooms for http://jenkins-x.io/community/[both IRC and slack] depending on which chat technology you prefer - as the Jenkins X community will be working closely with both the Jenkins community and the various Kubernetes communities (Kubernetes, Helm, Skaffold, Istio et al).
 
-One of the most rewarding things about Open Source is being able to learn from others in the community. So I'm hoping that even if you are not yet ready to use Kubernetes in your day job or are not yet interested in automating your Continuous Delivery - that you'll at least consider taking a look at Jenkins X, if for no other reason than to help you learn more about all these new ideas, technologies and approaches!
+One of the most rewarding things about open source is being able to learn from others in the community. So I'm hoping that even if you are not yet ready to use Kubernetes in your day job or are not yet interested in automating your Continuous Delivery - that you'll at least consider taking a look at Jenkins X, if for no other reason than to help you learn more about all these new ideas, technologies and approaches!
 
 Thanks for listening and I'm looking forward to http://jenkins-x.io/community/[seeing you in the community].
 


### PR DESCRIPTION
Hey James, nice work :) A couple edits from me:

- Use `CI/CD` instead of `CI / CD`
- Remove duplicate warning against using Minikube
- Consistent capitalization of tool names (vs. CLI commands, which should be lowercase)